### PR TITLE
Improve desktop responsiveness for smaller widow sizes

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -10,6 +10,7 @@ body {
     color: #FFFFFF;
     background-color: #041019;
     font-family: 'Roboto', sans-serif;
+    font-size:13px;
 }
 
 footer {
@@ -82,6 +83,10 @@ footer {
     padding-bottom: 20px;
 }
 
+.blockdetails {
+  padding-left: 0;
+}
+
 .blockdetails > div {
     margin-top: 5px;
     padding-left: 0;
@@ -93,9 +98,14 @@ footer {
     font-weight: 900;
 }
 
-.blockdetails > .row > div {
-    padding-left: 0px;
-    padding-right: 10px;
+.blockdetails > .row > .col-md-2 {
+    padding-left: 0;
+    padding-right: 0;
+}
+
+.blockdetails > row > .col-md-10 {
+    padding-left: 5%;
+    padding-right: 10%;
 }
 
 .mybar2 > .bardata > .bardatatitle {

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -26,7 +26,7 @@
         <div class="col-md-1"></div>
         <div class="col-md-10" style="text-align: center;">
             <div class="mybar col-md-12">
-                <div class="col-md-5" style="text-align: center;">
+                <div class="col-md-5" style="text-align: center; width:47.5%;">
                     <div class="Labels col-md-12">BLOCK DETAILS</div>
                     <div class="col-md-12">
                         <div class="col-md-6 pull-left blockdetails">
@@ -61,21 +61,21 @@
                         </div>
                         <div class="col-md-6 pull-left no-padding">
                             <canvas id="barChart"></canvas><br>
-                            Blocks Vs. Spec Last 6 Days
+                            Blocks vs. Spec last 6 days
                         </div>
                     </div>
                 </div>
-                <div class="col-md-2" style="text-align: center;">
+                <div class="col-md-2" style="text-align: center; width: 5%">
                     <div class="vr2" style="display: inline-block;">&nbsp;</div>
                 </div>
-                <div class="col-md-5" style="text-align: center;">
+                <div class="col-md-5" style="text-align: center; width: 47.5%">
                     <div class="Labels col-md-12">NODES BY COUNTRY</div>
                     <div class="col-md-12">
 						<?php $i = 1; ?>
                         @foreach ($country as $key => $value)
                             @if ($i <= 4)
                                 <div class="col-md-3">
-                                    <div style="height: 100px; width: 100px;">
+                                    <div style="height: 100px; width: 100px; margin: auto;">
                                         <canvas id="do{!! $i !!}Chart" width="400" height="400"></canvas>
                                         <br>
                                         {!! $value['country_name'] !!}


### PR DESCRIPTION
Shrink the middle divider block between Block Details and Nodes by Country
Add two blockdetails class selectors and reduce the padding
Center the Nodes by Country pies
Edit the Blocks vs. Spec text
Reduce the default font size to 13px